### PR TITLE
Support multiple features per feature command

### DIFF
--- a/engine/src/main/java/se/dykstrom/cet/engine/state/ConfiguredEngine.java
+++ b/engine/src/main/java/se/dykstrom/cet/engine/state/ConfiguredEngine.java
@@ -16,10 +16,12 @@
 
 package se.dykstrom.cet.engine.state;
 
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.regex.Pattern;
 
 import se.dykstrom.cet.engine.config.EngineConfig;
 import se.dykstrom.cet.engine.util.EngineFeatures;
@@ -29,7 +31,7 @@ import se.dykstrom.cet.engine.util.XboardCommand;
 
 import static java.lang.System.Logger.Level.DEBUG;
 import static java.lang.System.Logger.Level.INFO;
-import static java.util.stream.Collectors.toMap;
+import static se.dykstrom.cet.engine.util.StringUtils.unstringify;
 
 public record ConfiguredEngine(EngineConfig config, EngineProcess process) implements Engine {
 
@@ -43,6 +45,8 @@ public record ConfiguredEngine(EngineConfig config, EngineProcess process) imple
     private static final String FEATURE_REUSE = "reuse";
     private static final String FEATURE_TIME = "time";
     private static final String FEATURE_USER_MOVE = "usermove";
+
+    private static final Pattern FEATURE_PATTERN = Pattern.compile("(\\w+)=(\"(?:[^\"\\\\]|\\\\.)*\"|\\S+)");
 
     private static final Set<String> RECOGNIZED_FEATURES = Set.of(
             FEATURE_DEBUG,
@@ -61,20 +65,22 @@ public record ConfiguredEngine(EngineConfig config, EngineProcess process) imple
         loadedProcess.sendCommand(XboardCommand.XBOARD);
         loadedProcess.sendCommand(XboardCommand.PROTOVER, 2);
         loadedProcess.sendCommand(XboardCommand.FORCE);
-        final var response = loadedProcess.readUntil("feature done=1");
+        final var response = loadedProcess.readUntil("done=1");
         EngineFeatures features = parseFeatures(response, loadedProcess);
         LOGGER.log(DEBUG, "Recognized features: {0}", features);
         return new IdlingEngine(config, features, loadedProcess);
     }
 
-    @SuppressWarnings("java:S3824")
     private EngineFeatures parseFeatures(final List<String> response, EngineProcess loadedProcess) {
-        final Map<String, String> map = response.stream()
-                                                .filter(line -> line.startsWith("feature "))
-                                                .map(line -> line.substring("feature ".length()).split("="))
-                                                .collect(toMap(feature -> feature[0],
-                                                        feature -> StringUtils.unstringify(feature[1]),
-                                                        (v1, v2) -> v2));
+        final Map<String, String> map = new HashMap<>();
+        response.stream()
+                .filter(line -> line.startsWith("feature "))
+                .forEach(line -> {
+                    final var matcher = FEATURE_PATTERN.matcher(line.substring("feature ".length()));
+                    while (matcher.find()) {
+                        map.put(matcher.group(1), unstringify(matcher.group(2)));
+                    }
+                });
         // Accept recognized features
         RECOGNIZED_FEATURES.stream()
                            .filter(map::containsKey)

--- a/engine/src/test/java/se/dykstrom/cet/engine/state/ConfiguredEngineTest.java
+++ b/engine/src/test/java/se/dykstrom/cet/engine/state/ConfiguredEngineTest.java
@@ -28,6 +28,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static se.dykstrom.cet.engine.util.XboardCommand.ACCEPTED;
 import static se.dykstrom.cet.engine.util.XboardCommand.FORCE;
 import static se.dykstrom.cet.engine.util.XboardCommand.PROTOVER;
 import static se.dykstrom.cet.engine.util.XboardCommand.XBOARD;
@@ -41,14 +42,17 @@ class ConfiguredEngineTest {
     private static final EngineFeatures FEATURES_FOO = EngineFeatures.builder().myName("foo").userMove("1").build();
     private static final EngineFeatures FEATURES_BAR = EngineFeatures.builder().myName("bar").userMove("1").build();
 
+    private static final String DONE_REGEX = "done=1";
     private static final String FEATURE_DONE_0 = "feature done=0";
     private static final String FEATURE_DONE_1 = "feature done=1";
     private static final String FEATURE_MY_NAME_FOO = "feature myname=foo";
     private static final String FEATURE_MY_NAME_BAR = "feature myname=bar";
     private static final String FEATURE_USER_MOVE = "feature usermove=1";
+    private static final String FEATURE_MULTI = "feature myname=\"foo\" usermove=1 done=1";
 
     private static final List<String> FEATURE_RESPONSE_NORMAL = List.of(FEATURE_MY_NAME_FOO, FEATURE_USER_MOVE, FEATURE_DONE_1);
     private static final List<String> FEATURE_RESPONSE_DELAYED = List.of(FEATURE_DONE_0, FEATURE_MY_NAME_BAR, FEATURE_USER_MOVE, FEATURE_DONE_1);
+    private static final List<String> FEATURE_RESPONSE_MULTI = List.of(FEATURE_MULTI);
 
     private final EngineProcess unloadedProcessMock = mock(EngineProcess.class);
     private final EngineProcess loadedProcessMock = mock(EngineProcess.class);
@@ -58,7 +62,7 @@ class ConfiguredEngineTest {
         // Given
         final var configuredEngine = new ConfiguredEngine(CONFIG, unloadedProcessMock);
         when(unloadedProcessMock.startUp(ID, OS_COMMAND, DIRECTORY)).thenReturn(loadedProcessMock);
-        when(loadedProcessMock.readUntil(FEATURE_DONE_1)).thenReturn(FEATURE_RESPONSE_NORMAL);
+        when(loadedProcessMock.readUntil(DONE_REGEX)).thenReturn(FEATURE_RESPONSE_NORMAL);
 
         // When
         final IdlingEngine idlingEngine = configuredEngine.load();
@@ -71,7 +75,26 @@ class ConfiguredEngineTest {
         verify(loadedProcessMock).sendCommand(XBOARD);
         verify(loadedProcessMock).sendCommand(PROTOVER, 2);
         verify(loadedProcessMock).sendCommand(FORCE);
-        verify(loadedProcessMock).readUntil(FEATURE_DONE_1);
+        verify(loadedProcessMock).readUntil(DONE_REGEX);
+    }
+
+    @Test
+    void shouldLoadEngineWithMultipleFeaturesPerCommand() {
+        // Given
+        final var configuredEngine = new ConfiguredEngine(CONFIG, unloadedProcessMock);
+        when(unloadedProcessMock.startUp(ID, OS_COMMAND, DIRECTORY)).thenReturn(loadedProcessMock);
+        when(loadedProcessMock.readUntil(DONE_REGEX)).thenReturn(FEATURE_RESPONSE_MULTI);
+
+        // When
+        final IdlingEngine idlingEngine = configuredEngine.load();
+
+        // Then
+        assertEquals(CONFIG, idlingEngine.engineConfig());
+        assertEquals(FEATURES_FOO, idlingEngine.features());
+        assertEquals(loadedProcessMock, idlingEngine.process());
+        verify(loadedProcessMock).sendCommand(ACCEPTED, "done");
+        verify(loadedProcessMock).sendCommand(ACCEPTED, "myname");
+        verify(loadedProcessMock).sendCommand(ACCEPTED, "usermove");
     }
 
     @Test
@@ -79,7 +102,7 @@ class ConfiguredEngineTest {
         // Given
         final var configuredEngine = new ConfiguredEngine(CONFIG, unloadedProcessMock);
         when(unloadedProcessMock.startUp(ID, OS_COMMAND, DIRECTORY)).thenReturn(loadedProcessMock);
-        when(loadedProcessMock.readUntil(FEATURE_DONE_1)).thenReturn(FEATURE_RESPONSE_DELAYED);
+        when(loadedProcessMock.readUntil(DONE_REGEX)).thenReturn(FEATURE_RESPONSE_DELAYED);
 
         // When
         final IdlingEngine idlingEngine = configuredEngine.load();
@@ -92,6 +115,6 @@ class ConfiguredEngineTest {
         verify(loadedProcessMock).sendCommand(XBOARD);
         verify(loadedProcessMock).sendCommand(PROTOVER, 2);
         verify(loadedProcessMock).sendCommand(FORCE);
-        verify(loadedProcessMock).readUntil(FEATURE_DONE_1);
+        verify(loadedProcessMock).readUntil(DONE_REGEX);
     }
 }

--- a/engine/src/test/java/se/dykstrom/cet/engine/util/StringUtilsTest.java
+++ b/engine/src/test/java/se/dykstrom/cet/engine/util/StringUtilsTest.java
@@ -23,6 +23,14 @@ import static org.junit.jupiter.api.Assertions.*;
 class StringUtilsTest {
 
     @Test
+    void shouldUnstringify() {
+        assertEquals("foo", StringUtils.unstringify("\"foo\""));
+        assertEquals("", StringUtils.unstringify("\"\""));
+        assertEquals("foo", StringUtils.unstringify("foo"));
+        assertEquals("1", StringUtils.unstringify("1"));
+    }
+
+    @Test
     void shouldExtractEngineName() {
         assertEquals("gnuchess", StringUtils.getNameFromCommand("gnuchess"));
         assertEquals("gnuchess", StringUtils.getNameFromCommand("/usr/local/bin/gnuchess"));


### PR DESCRIPTION
Parse all key=value pairs from a single feature line using a regex instead of splitting on '=', enabling engines that send multiple features in one command (e.g. 'feature myname="foo" usermove=1 done=1'). Also fix readUntil regex to match done=1 anywhere in a feature line.